### PR TITLE
feat: 일기 기록/메인 뷰 퍼블리싱

### DIFF
--- a/src/pages/diary/diary-create-page.tsx
+++ b/src/pages/diary/diary-create-page.tsx
@@ -2,17 +2,46 @@ import DiaryCompleteSheet from '@components/bottom-sheet/diary-complete-sheet';
 import { PrimaryStrongCTA } from '@components/button/cta-button';
 import InputField from '@components/inputfield';
 import TextField from '@components/textfield';
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import type { DiaryEntry } from '@pages/diary/diary-page';
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+type DiaryCreateState =
+  | { mode: 'create'; date: string }
+  | { mode: 'edit'; date: string; entry: DiaryEntry };
 
 export default function DiaryCreatePage() {
+  const { state } = useLocation() as { state?: DiaryCreateState };
+  const mode = state?.mode ?? 'create';
+  const date = state?.date ?? '';
+  const initial = useMemo(
+    () =>
+      mode === 'edit' && state && 'entry' in state
+        ? {
+            title: state.entry.title,
+            emotions: state.entry.emotions.join(', '),
+            content: state.entry.content,
+          }
+        : { title: '', emotions: '', content: '' },
+    [mode, state],
+  );
+
   const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState(initial.title);
+  const [emotions, setEmotions] = useState(initial.emotions);
+  const [content, setContent] = useState(initial.content);
+
+  useEffect(() => {
+    setTitle(initial.title);
+    setEmotions(initial.emotions);
+    setContent(initial.content);
+  }, [initial]);
+
   const navigate = useNavigate();
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
   const handleGoRecords = () => {
-    // TODO: 분석 화면 연결 -> 분석 완료 화면 연결(컴포넌트 갈아끼우기!)
     setOpen(false);
   };
 
@@ -21,23 +50,42 @@ export default function DiaryCreatePage() {
     setOpen(false);
   };
 
+  const ctaLabel = mode === 'edit' ? '수정 완료' : '작성 완료';
+
   return (
     <div className="flex-col gap-[5rem] px-[2.5rem] pt-[2.2rem] pb-[20rem]">
       <div className="flex-col gap-[2rem]">
         <div className="flex-col gap-[1rem]">
           <span className="heading3-700 text-gray-900">제목</span>
-          <InputField placeholder="제목을 입력해 주세요 (최대 100자 이내)" />
+          <InputField
+            placeholder="제목을 입력해 주세요 (최대 100자 이내)"
+            value={title}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+          />
         </div>
+
         <div className="flex-col gap-[1rem]">
           <span className="heading3-700 text-gray-900">오늘의 감정</span>
-          <InputField placeholder="감정을 아래에서 선택하거나 직접 입력해 주세요" />
+          <InputField
+            placeholder="감정을 아래에서 선택하거나 직접 입력해 주세요 (쉼표로 구분)"
+            value={emotions}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmotions(e.target.value)}
+          />
         </div>
+
         <div className="flex-col gap-[1rem]">
-          <span className="heading3-700 text-gray-900">제목</span>
-          <TextField placeholder="일기 내용을 입력해 주세요" />
+          <span className="heading3-700 text-gray-900">내용</span>
+          <TextField
+            placeholder="일기 내용을 입력해 주세요"
+            value={content}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setContent(e.target.value)}
+          />
         </div>
+
+        {date && <div className="detail text-gray-500">{date}</div>}
       </div>
-      <PrimaryStrongCTA onClick={handleOpen}>작성 완료</PrimaryStrongCTA>
+
+      <PrimaryStrongCTA onClick={handleOpen}>{ctaLabel}</PrimaryStrongCTA>
 
       <DiaryCompleteSheet
         isOpen={open}

--- a/src/pages/diary/diary-page.tsx
+++ b/src/pages/diary/diary-page.tsx
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-type DiaryEntry = {
+export type DiaryEntry = {
   title: string;
   content: string;
   emotions: string[];

--- a/src/pages/diary/diary-page.tsx
+++ b/src/pages/diary/diary-page.tsx
@@ -12,6 +12,10 @@ export type DiaryEntry = {
   emotions: string[];
 };
 
+type DiaryCreateState =
+  | { mode: 'create'; date: string }
+  | { mode: 'edit'; date: string; entry: DiaryEntry };
+
 const DIARY_ENTRIES: Record<string, DiaryEntry> = {
   '2025-08-01': {
     title: '오늘은...',
@@ -62,10 +66,13 @@ export default function DiaryPage() {
 
   const handleCardAction = (type: '작성하기' | '수정하기') => {
     if (type === '작성하기') {
-      navigate(`/diary/record?date=${selectedKey}`);
-    } else {
-      navigate(`/diary/record?date=${selectedKey}&mode=edit`);
+      const state: DiaryCreateState = { mode: 'create', date: selectedKey };
+      navigate('/diary/create', { state });
+      return;
     }
+    if (!entry) return;
+    const state: DiaryCreateState = { mode: 'edit', date: selectedKey, entry };
+    navigate('/diary/create', { state });
   };
 
   return (

--- a/src/pages/diary/diary-page.tsx
+++ b/src/pages/diary/diary-page.tsx
@@ -1,14 +1,72 @@
 import Button from '@components/button/button';
 import Calendar from '@components/calendar/calendar';
+import DiaryCard from '@components/card/diary-card';
 import Banner from '@pages/diary/components/banner';
-import { useState } from 'react';
+import dayjs from 'dayjs';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+type DiaryEntry = {
+  title: string;
+  content: string;
+  emotions: string[];
+};
+
+const DIARY_ENTRIES: Record<string, DiaryEntry> = {
+  '2025-08-01': {
+    title: '오늘은...',
+    content: '맛있는 걸 먹어서 기분이 좋은 날이다.',
+    emotions: ['HAPPY'],
+  },
+  '2025-08-08': {
+    title: '집중의 하루',
+    content: '순공 시간 12시간 달성했다. 재미 없다.,,',
+    emotions: ['SAD', 'ANGRY'],
+  },
+  '2025-08-09': {
+    title: '휴식',
+    content: '산책으로 머리 식혔다...',
+    emotions: ['SAD'],
+  },
+  '2025-08-15': {
+    title: '왠지 기분이 좋은 날',
+    content: '오랜만에 나들이',
+    emotions: ['EXCITE'],
+  },
+  '2025-08-27': {
+    title: '좋아하는 친구들을 만났다.',
+    content: '역시 친구들을 만나니까 기분이 좋은 것 같다.',
+    emotions: ['EXCITE'],
+  },
+  '2025-09-03': {
+    title: '행복',
+    content: '좋아하는 휘낭시에랑 마들렌을 잔뜩 먹었다!! 맛있으면 0칼로리;;',
+    emotions: ['HAPPY'],
+  },
+  '2025-09-14': {
+    title: '슬픈 영화를 봤다.',
+    content: '베일리 어게인 보고 내내 울었다...',
+    emotions: ['SAD'],
+  },
+};
 
 export default function DiaryPage() {
   const [selected, setSelected] = useState(new Date());
   const navigate = useNavigate();
 
+  const selectedKey = useMemo(() => dayjs(selected).format('YYYY-MM-DD'), [selected]);
+
+  const entry = DIARY_ENTRIES[selectedKey];
+  const markedDates = useMemo(() => Object.keys(DIARY_ENTRIES), []);
   const goRecord = () => navigate('/diary/record');
+
+  const handleCardAction = (type: '작성하기' | '수정하기') => {
+    if (type === '작성하기') {
+      navigate(`/diary/record?date=${selectedKey}`);
+    } else {
+      navigate(`/diary/record?date=${selectedKey}&mode=edit`);
+    }
+  };
 
   return (
     <div className="min-h-dvh w-full flex-col bg-cover bg-gradient-bgd1 bg-no-repeat pb-[17rem]">
@@ -27,19 +85,17 @@ export default function DiaryPage() {
           </Button>
         </div>
 
-        <Calendar
-          value={selected}
-          onChange={setSelected}
-          marked={[
-            '2025-08-01',
-            '2025-08-08',
-            '2025-08-09',
-            '2025-08-15',
-            '2025-08-27',
-            '2025-09-03',
-            '2025-09-14',
-          ]}
-        />
+        <Calendar value={selected} onChange={setSelected} marked={markedDates} />
+
+        <div className="pt-[1.6rem] pb-[2.4rem]">
+          <DiaryCard
+            title={entry?.title}
+            content={entry?.content}
+            emotions={entry?.emotions ?? []}
+            date={selected}
+            onClickButton={handleCardAction}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/diary/diary-record-page.tsx
+++ b/src/pages/diary/diary-record-page.tsx
@@ -1,9 +1,62 @@
 import Calendar from '@components/calendar/calendar';
+import DiaryCard from '@components/card/diary-card';
 import TipInfo from '@components/tipinfo';
-import { useState } from 'react';
+import type { DiaryEntry } from '@pages/diary/diary-page';
+import dayjs from 'dayjs';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const DIARY_ENTRIES: Record<string, DiaryEntry> = {
+  '2025-08-01': {
+    title: '오늘은...',
+    content: '맛있는 걸 먹어서 기분이 좋은 날이다.',
+    emotions: ['HAPPY'],
+  },
+  '2025-08-08': {
+    title: '집중의 하루',
+    content: '순공 시간 12시간 달성했다. 재미 없다,,',
+    emotions: ['SAD', 'ANGRY'],
+  },
+  '2025-08-09': {
+    title: '휴식',
+    content: '산책으로 머리 식혔다...',
+    emotions: ['SAD'],
+  },
+  '2025-08-15': {
+    title: '왠지 기분이 좋은 날',
+    content: '오랜만에 나들이',
+    emotions: ['EXCITE'],
+  },
+  '2025-08-27': {
+    title: '좋아하는 친구들을 만났다.',
+    content: '역시 친구들을 만나니까 기분이 좋은 것 같다.',
+    emotions: ['EXCITE'],
+  },
+  '2025-09-03': {
+    title: '행복',
+    content: '좋아하는 휘낭시에랑 마들렌을 잔뜩 먹었다!! 맛있으면 0칼로리;;',
+    emotions: ['HAPPY'],
+  },
+  '2025-09-14': {
+    title: '슬픈 영화를 봤다.',
+    content: '베일리 어게인 보고 내내 울었다...',
+    emotions: ['SAD'],
+  },
+};
 
 export default function DiaryRecordPage() {
   const [selected, setSelected] = useState(new Date());
+  const navigate = useNavigate();
+
+  const selectedKey = useMemo(() => dayjs(selected).format('YYYY-MM-DD'), [selected]);
+  const entry = DIARY_ENTRIES[selectedKey];
+
+  const marked = useMemo(() => Object.keys(DIARY_ENTRIES), []);
+
+  const onCardAction = (type: '작성하기' | '수정하기') => {
+    if (type === '작성하기') navigate(`/diary/record?date=${selectedKey}`);
+    else navigate(`/diary/record?date=${selectedKey}&mode=edit`);
+  };
 
   return (
     <div className="flex-col gap-[3rem] px-[2.4rem] pt-[2.2rem] pb-[17rem]">
@@ -11,25 +64,23 @@ export default function DiaryRecordPage() {
         title="나의 감정 일기 기록 이용 TIP"
         text="아래 날짜를 클릭하면 당시 기록한 감정 일기를 볼 수 있어요"
       />
+
       <div className="flex-col gap-[1.5rem]">
         <h1 className="heading1-700">월별 기록</h1>
         <section>
-          <Calendar
-            value={selected}
-            onChange={setSelected}
-            marked={[
-              '2025-08-01',
-              '2025-08-08',
-              '2025-08-09',
-              '2025-08-15',
-              '2025-08-27',
-              '2025-09-03',
-              '2025-09-14',
-            ]}
-          />
+          <Calendar value={selected} onChange={setSelected} marked={marked} />
         </section>
       </div>
-      <div>{/* TODO: 다이어리 컴포넌트 추가 */}</div>
+
+      <div className="pt-[0.8rem]">
+        <DiaryCard
+          title={entry?.title}
+          content={entry?.content}
+          emotions={entry?.emotions ?? []}
+          date={selected}
+          onClickButton={onCardAction}
+        />
+      </div>
     </div>
   );
 }

--- a/src/pages/diary/diary-record-page.tsx
+++ b/src/pages/diary/diary-record-page.tsx
@@ -6,6 +6,10 @@ import dayjs from 'dayjs';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+type DiaryCreateState =
+  | { mode: 'create'; date: string }
+  | { mode: 'edit'; date: string; entry: DiaryEntry };
+
 const DIARY_ENTRIES: Record<string, DiaryEntry> = {
   '2025-08-01': {
     title: '오늘은...',
@@ -50,12 +54,18 @@ export default function DiaryRecordPage() {
 
   const selectedKey = useMemo(() => dayjs(selected).format('YYYY-MM-DD'), [selected]);
   const entry = DIARY_ENTRIES[selectedKey];
-
   const marked = useMemo(() => Object.keys(DIARY_ENTRIES), []);
 
   const onCardAction = (type: '작성하기' | '수정하기') => {
-    if (type === '작성하기') navigate(`/diary/record?date=${selectedKey}`);
-    else navigate(`/diary/record?date=${selectedKey}&mode=edit`);
+    if (type === '작성하기') {
+      const state: DiaryCreateState = { mode: 'create', date: selectedKey };
+      navigate('/diary/create', { state });
+      return;
+    }
+
+    if (!entry) return;
+    const state: DiaryCreateState = { mode: 'edit', date: selectedKey, entry };
+    navigate('/diary/create', { state });
   };
 
   return (

--- a/src/shared/components/card/diary-card.tsx
+++ b/src/shared/components/card/diary-card.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/button/button';
 import Chips from '@components/chips/chips';
 import Divider from '@components/divider';
+import { cn } from '@libs/cn';
 import dayjs from 'dayjs';
 
 interface DiaryCardProps {
@@ -9,14 +10,27 @@ interface DiaryCardProps {
   emotions?: string[];
   date?: Date;
   onClickButton?: (type: '작성하기' | '수정하기') => void;
+  className?: string;
 }
 
-const DiaryCard = ({ title, content, emotions, date, onClickButton }: DiaryCardProps) => {
+const DiaryCard = ({
+  title,
+  content,
+  emotions,
+  date,
+  className = 'bg-gray-50',
+  onClickButton,
+}: DiaryCardProps) => {
   const isEmpty = !title && !content && emotions?.length === 0;
   const type = isEmpty ? '작성하기' : '수정하기';
 
   return (
-    <div className="w-full flex-col gap-[1.2rem] rounded-[20px] border border-gray-200 p-[1.6rem]">
+    <div
+      className={cn(
+        'w-full flex-col gap-[1.2rem] rounded-[20px] border border-gray-200 p-[1.6rem]',
+        className,
+      )}
+    >
       {!isEmpty && (
         <>
           <p className="heading3-500">{title}</p>


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #44

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 개요

일기 기록 페이지와 일기 메인 페이지 뷰를 구현했습니다.
diary card 상위 div를 따로 두고 배경색을 설정하는 게 좋지 않은 로직이라는 생각이 들어서 컴포넌트를 사용하는 페이지에서 cn 유틸을 활용해 className을 설정할 수 있도록 수정했습니다.

또 일기 작성 페이지에 상태를 넘겨서 수정/작성이 가능하도록 임시 구현하였습니다. 이 부분은 api 연동 이후에 실제 데이터로 수정해야 합니다!

## 💡 해결한 이슈 목록

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 체크 사항

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. !-->

- [ ] 커밋/코딩 컨벤션에 맞게 작성
- [ ] 변경 사항에 대한 테스트

<!---- UI 작업의 경우 변경된 이미지나 비디오를 첨부해 주세요. !-->

## 📷 Screenshots or Video

<!---- 없는 경우 삭제 부탁드립니다~! !-->

https://github.com/user-attachments/assets/550ed6fc-3121-4a8c-86f1-b09ccb409ae0

