### PR TITLE
style: splash 수정

### DIFF
--- a/src/shared/layouts/layout.tsx
+++ b/src/shared/layouts/layout.tsx
@@ -1,7 +1,7 @@
 import Header, { type HeaderProps } from '@layouts/header-bar';
 import NavigationBar from '@layouts/nav-bar';
 import Splash from '@layouts/splash';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Outlet, ScrollRestoration, useLocation, useMatches, useNavigate } from 'react-router-dom';
 
 const EXCEPTION_HEADERS: Array<{
@@ -42,17 +42,14 @@ export default function Layout() {
   const hideChrome = !!last?.handle?.hideChrome;
 
   const [showSplash, setShowSplash] = useState(() => !sessionStorage.getItem('splashSeen'));
-  useEffect(() => {
-    if (!showSplash) return;
-    const t = setTimeout(() => {
-      sessionStorage.setItem('splashSeen', '1');
-      setShowSplash(false);
-    }, 1200);
-    return () => clearTimeout(t);
-  }, [showSplash]);
+
+  const handleSplashDone = () => {
+    sessionStorage.setItem('splashSeen', '1');
+    setShowSplash(false);
+  };
 
   if (showSplash) {
-    return <Splash />;
+    return <Splash onComplete={handleSplashDone} />;
   }
 
   return (

--- a/src/shared/layouts/splash.tsx
+++ b/src/shared/layouts/splash.tsx
@@ -1,17 +1,82 @@
+import LogoIcon from '@assets/icons/logo.svg?react';
 import Intro from '@components/intro';
 import { cn } from '@libs/cn';
+import { useEffect, useState } from 'react';
 
-export default function Splash() {
+const PHASE0_MS = 900;
+const PHASE1_MS = 900;
+const ICON_FADE_MS = 800;
+
+type SplashProps = {
+  onComplete?: () => void;
+};
+
+export default function Splash({ onComplete }: SplashProps) {
+  const [phase, setPhase] = useState<0 | 1 | 2>(0);
+  const [iconVisible, setIconVisible] = useState(false);
+
+  useEffect(() => {
+    const t1 = window.setTimeout(() => setPhase(1), PHASE0_MS);
+    const t2 = window.setTimeout(() => setPhase(2), PHASE0_MS + PHASE1_MS);
+    const t3 = window.setTimeout(() => onComplete?.(), PHASE0_MS + PHASE1_MS + ICON_FADE_MS);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [onComplete]);
+
+  useEffect(() => {
+    if (phase === 2) {
+      setIconVisible(false);
+      const raf = requestAnimationFrame(() => setIconVisible(true));
+      return () => cancelAnimationFrame(raf);
+    }
+  }, [phase]);
+
   return (
     <div
       className={cn(
         'fixed inset-0 z-[var(--z-splash)]',
         'mx-auto grid h-full w-full max-w-[43rem] place-items-center',
-        'bg-gray-50',
-        'px-[2.4rem]',
+        'bg-gray-50 px-[2.4rem]',
       )}
     >
-      <Intro />
+      {phase === 0 && (
+        <Intro
+          key="phase-0"
+          highlightColor="gray"
+          icon={<span aria-hidden className="block h-full w-full" />}
+          iconClassName="h-[12rem] w-[12rem]"
+        />
+      )}
+
+      {phase === 1 && (
+        <Intro
+          key="phase-1"
+          highlightColor="primary"
+          icon={<span aria-hidden className="block h-full w-full" />}
+          iconClassName="h-[12rem] w-[12rem]"
+        />
+      )}
+
+      {phase === 2 && (
+        <Intro
+          key="phase-2"
+          highlightColor="primary"
+          icon={
+            <LogoIcon
+              aria-hidden
+              className={cn(
+                'h-full w-full transform transition-[opacity,transform] duration-500 ease-in',
+                iconVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0',
+                'motion-reduce:scale-100 motion-reduce:opacity-100 motion-reduce:transition-none',
+              )}
+            />
+          }
+          iconClassName="h-[12rem] w-[12rem]"
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

Closes #51


## 🔎 개요

* **스플래시 화면 전환 시퀀스**를 “회색 하이라이트 → 프라이머리 하이라이트 → 아이콘”의 3단계로 구현했습니다.
* 스플래시의 **표시/종료 타이밍을 Splash 내부가 주도**하도록 변경하고, 완료 시 `onComplete` 콜백으로 Layout에 종료됨을 알려줍니다!
* 세션당 1회만 노출되도록 `sessionStorage('splashSeen')`를 유지합니다.

## ✨ 변경 사항

### 1) `@layouts/splash`

* 단계(state) 기반 렌더링

  * `phase 0`(900ms): `highlightColor="gray"`, 아이콘 숨김
  * `phase 1`(900ms): `highlightColor="primary"`, 아이콘 숨김
  * `phase 2`(+아이콘 500ms 페이드/스케일 인): `highlightColor="primary"`, 아이콘 표시
* `Intro`가 기본 아이콘을 렌더하지 않도록, 아이콘 숨김 단계에서는 **빈 노드**를 명시적으로 전달
* 애니메이션

  * 아이콘: `transition-[opacity,transform] duration-500 ease-in`
  * 2단계 진입 시 `requestAnimationFrame`으로 다음 프레임에 `opacity/scale` 트리거하여 자연스럽게 전환
* 시퀀스 완료 시 `onComplete()` 호출로 상위(Layout)에게 끝났음을 알려줍니다.

### 2) `Layout` 수정

* 기존 1.2초 타이머로 스플래시를 강제 언마운트하던 로직 **제거**
* `showSplash`는 `sessionStorage('splashSeen')` 여부로 결정하고,

  * `true`면 `<Splash onComplete={handleSplashDone} />` 반환합니다.
  * `handleSplashDone`에서 `sessionStorage.setItem('splashSeen','1')` 후 `showSplash=false`로 전환합니다.

## 💡 해결한 이슈 목록

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 체크 사항

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. !-->

- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 변경 사항에 대한 테스트

<!---- UI 작업의 경우 변경된 이미지나 비디오를 첨부해 주세요. !-->

## 📷 Screenshots or Video

<!---- 없는 경우 삭제 부탁드립니다~! !-->

https://github.com/user-attachments/assets/863aa360-5709-4f1d-b693-11a5a05a6f70

